### PR TITLE
Fix analytics KPI data source and time filtering

### DIFF
--- a/tracker/templates/tracker/analytics_service.html
+++ b/tracker/templates/tracker/analytics_service.html
@@ -332,7 +332,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Total Orders</h6>
-              <h3 class="mb-1">{{ kpis_all.total_orders|default:kpis.total_orders|default:0 }}</h3>
+              <h3 class="mb-1">{{ kpis.total_orders|default:0 }}</h3>
               {% with delta=kpis.order_change|default:0 %}
               <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
                 <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
@@ -355,7 +355,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Tire Sales</h6>
-              <h3 class="mb-1">{{ kpis_all.total_tire_sales|default:kpis.total_tire_sales|default:0 }}</h3>
+              <h3 class="mb-1">{{ kpis.total_tire_sales|default:0 }}</h3>
               {% with delta=kpis.tire_sales_change|default:0 %}
               <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
                 <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
@@ -378,7 +378,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Car Service</h6>
-              <h3 class="mb-1">{{ kpis_all.total_car_service|default:kpis.total_car_service|default:0 }}</h3>
+              <h3 class="mb-1">{{ kpis.total_car_service|default:0 }}</h3>
               {% with delta=kpis.car_service_change|default:0 %}
               <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
                 <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
@@ -401,7 +401,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Inquiries</h6>
-              <h3 class="mb-1">{{ kpis_all.total_inquiries|default:kpis.total_inquiries|default:0 }}</h3>
+              <h3 class="mb-1">{{ kpis.total_inquiries|default:0 }}</h3>
               {% with delta=kpis.inquiry_change|default:0 %}
               <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
                 <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>

--- a/tracker/templates/tracker/analytics_service.html
+++ b/tracker/templates/tracker/analytics_service.html
@@ -332,10 +332,13 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Total Orders</h6>
-              <h3 class="mb-1">{{ by_type_values_sum|default:0 }}</h3>
-              <span class="text-success small">
-                <i class="fas fa-arrow-up"></i> 12% from last period
+              <h3 class="mb-1">{{ kpis.total_orders|default:0 }}</h3>
+              {% with delta=kpis.order_change|default:0 %}
+              <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
+                <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
+                {{ delta }}% from last period
               </span>
+              {% endwith %}
             </div>
             <div class="stat-icon bg-soft-primary rounded p-3">
               <i class="fas fa-shopping-cart text-primary"></i>
@@ -352,10 +355,13 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Tire Sales</h6>
-              <h3 class="mb-1">{{ by_type.sales|default:0 }}</h3>
-              <span class="text-success small">
-                <i class="fas fa-arrow-up"></i> 8% from last period
+              <h3 class="mb-1">{{ kpis.total_tire_sales|default:0 }}</h3>
+              {% with delta=kpis.tire_sales_change|default:0 %}
+              <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
+                <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
+                {{ delta }}% from last period
               </span>
+              {% endwith %}
             </div>
             <div class="stat-icon bg-soft-success rounded p-3">
               <i class="fas fa-tire text-success"></i>
@@ -372,10 +378,13 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Car Service</h6>
-              <h3 class="mb-1">{{ by_type.service|default:0 }}</h3>
-              <span class="text-danger small">
-                <i class="fas fa-arrow-down"></i> 3% from last period
+              <h3 class="mb-1">{{ kpis.total_car_service|default:0 }}</h3>
+              {% with delta=kpis.car_service_change|default:0 %}
+              <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
+                <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
+                {{ delta }}% from last period
               </span>
+              {% endwith %}
             </div>
             <div class="stat-icon bg-soft-info rounded p-3">
               <i class="fas fa-car text-info"></i>
@@ -392,10 +401,13 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Inquiries</h6>
-              <h3 class="mb-1">{{ by_type.inquiry|default:0 }}</h3>
-              <span class="text-success small">
-                <i class="fas fa-arrow-up"></i> 15% from last period
+              <h3 class="mb-1">{{ kpis.total_inquiries|default:0 }}</h3>
+              {% with delta=kpis.inquiry_change|default:0 %}
+              <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
+                <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
+                {{ delta }}% from last period
               </span>
+              {% endwith %}
             </div>
             <div class="stat-icon bg-soft-warning rounded p-3">
               <i class="fas fa-question-circle text-warning"></i>

--- a/tracker/templates/tracker/analytics_service.html
+++ b/tracker/templates/tracker/analytics_service.html
@@ -332,7 +332,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Total Orders</h6>
-              <h3 class="mb-1">{{ kpis.total_orders|default:0 }}</h3>
+              <h3 class="mb-1">{{ kpis_all.total_orders|default:kpis.total_orders|default:0 }}</h3>
               {% with delta=kpis.order_change|default:0 %}
               <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
                 <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
@@ -355,7 +355,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Tire Sales</h6>
-              <h3 class="mb-1">{{ kpis.total_tire_sales|default:0 }}</h3>
+              <h3 class="mb-1">{{ kpis_all.total_tire_sales|default:kpis.total_tire_sales|default:0 }}</h3>
               {% with delta=kpis.tire_sales_change|default:0 %}
               <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
                 <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
@@ -378,7 +378,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Car Service</h6>
-              <h3 class="mb-1">{{ kpis.total_car_service|default:0 }}</h3>
+              <h3 class="mb-1">{{ kpis_all.total_car_service|default:kpis.total_car_service|default:0 }}</h3>
               {% with delta=kpis.car_service_change|default:0 %}
               <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
                 <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>
@@ -401,7 +401,7 @@
           <div class="d-flex justify-content-between align-items-center">
             <div>
               <h6 class="text-muted mb-2">Inquiries</h6>
-              <h3 class="mb-1">{{ kpis.total_inquiries|default:0 }}</h3>
+              <h3 class="mb-1">{{ kpis_all.total_inquiries|default:kpis.total_inquiries|default:0 }}</h3>
               {% with delta=kpis.inquiry_change|default:0 %}
               <span class="small {% if delta >= 0 %}text-success{% else %}text-danger{% endif %}">
                 <i class="fas {% if delta >= 0 %}fa-arrow-up{% else %}fa-arrow-down{% endif %}"></i>

--- a/tracker/views.py
+++ b/tracker/views.py
@@ -4935,7 +4935,7 @@ def analytics_service(request: HttpRequest):
     from django.db.models import Count
     from django.db.models.functions import TruncDate, Lower, Trim
     import json
-    
+
     # Filters
     f_from = request.GET.get("from")
     f_to = request.GET.get("to")
@@ -4974,29 +4974,42 @@ def analytics_service(request: HttpRequest):
     qs = scope_queryset(Order.objects.all().select_related("customer"), request.user, request)
     qs = qs.filter(created_at__date__gte=start_date, created_at__date__lte=end_date)
 
-    # Counts by type and status
-    by_type = {r["type"] or "": r["c"] for r in qs.values("type").annotate(c=Count("id"))}
+    # Helper to normalize legacy/variant types to canonical buckets
+    def norm_type(t: str) -> str:
+        t = (t or '').strip().lower()
+        if t in ("consultation", "inquiries"):
+            return "inquiry"
+        if t in ("sales", "service", "inquiry"):
+            return t
+        return t or ""
+
+    # Counts by type (normalized) and status
+    raw_by_type = {r["type"] or "": r["c"] for r in qs.values("type").annotate(c=Count("id"))}
+    by_type = {"sales": 0, "service": 0, "inquiry": 0}
+    for t, c in raw_by_type.items():
+        by_type[norm_type(t)] = by_type.get(norm_type(t), 0) + int(c or 0)
     by_status = {r["status"] or "": r["c"] for r in qs.values("status").annotate(c=Count("id"))}
 
-    # Status by type matrix for stacked chart
+    # Status by type matrix for stacked chart (normalize type)
     status_order = ["created", "in_progress", "completed", "cancelled"]
     type_order = ["sales", "service", "inquiry"]
-    status_by_app = { (r["type"] or "", r["status"] or ""): r["c"] for r in qs.values("type", "status").annotate(c=Count("id")) }
+    raw_status = {
+        (norm_type(r["type"] or ""), r["status"] or ""): r["c"]
+        for r in qs.values("type", "status").annotate(c=Count("id"))
+    }
     status_series = [
         {
             "name": t.title(),
-            "data": [status_by_app.get((t, s), 0) for s in status_order],
+            "data": [raw_status.get((t, s), 0) for s in status_order],
         }
         for t in type_order
     ]
 
-    # Trend data per day by type
+    # Trend data per day by type (normalize type)
     trend_days = (end_date - start_date).days + 1
     trend_labels = [(start_date + timezone.timedelta(days=i)).strftime("%b %d") for i in range(trend_days)]
-    trend_map = {
-        (row["day"], row["type"]): row["c"]
-        for row in qs.annotate(day=TruncDate("created_at")).values("day", "type").annotate(c=Count("id"))
-    }
+    trend_rows = qs.annotate(day=TruncDate("created_at")).values("day", "type").annotate(c=Count("id"))
+    trend_map = { (row["day"], norm_type(row["type"])): row["c"] for row in trend_rows }
     trend_series = []
     for t in type_order:
         values = [trend_map.get((start_date + timezone.timedelta(days=i), t), 0) for i in range(trend_days)]
@@ -5005,7 +5018,6 @@ def analytics_service(request: HttpRequest):
     # Sales breakdowns (normalize brand and tire types)
     sales_qs = qs.filter(type="sales")
     from django.db.models.functions import Lower, Trim
-    # DB-side normalization to avoid case/space duplicates; fall back to 'Unknown' for blanks
     brands_norm = (
         sales_qs
         .annotate(_b=Lower(Trim('brand')))
@@ -5013,7 +5025,6 @@ def analytics_service(request: HttpRequest):
         .annotate(c=Count('id'))
         .order_by('-c', '_b')
     )
-    # Build labels/values aligned, with human-friendly labels (title-cased) and include top 12
     top_brand_items = []
     for row in brands_norm[:12]:
         key = row.get('_b') or ''
@@ -5039,22 +5050,21 @@ def analytics_service(request: HttpRequest):
     for row in sales_qs.values("tire_type"):
         key = _norm_tire_type(row.get("tire_type"))
         tire_counts[key] = tire_counts.get(key, 0) + 1
-    # Keep a consistent order
     tire_order = ["New", "Used", "Refurbished", "Unknown"]
     tire_types = {
         "labels": [k for k in tire_order if k in tire_counts],
         "values": [tire_counts[k] for k in tire_order if k in tire_counts],
     }
 
-    # Inquiry breakdowns
-    inquiry_qs = qs.filter(type="inquiry")
+    # Inquiry breakdowns (include legacy consultation)
+    inquiry_qs = qs.filter(type__in=["inquiry", "consultation"])
     inquiry_types_qs = inquiry_qs.values("inquiry_type").annotate(c=Count("id")).order_by("-c")
     inquiry_types = {
         "labels": [r["inquiry_type"] or "Other" for r in inquiry_types_qs],
         "values": [r["c"] for r in inquiry_types_qs],
     }
 
-    # Types pie
+    # Types pie (normalized)
     types_chart = {
         "labels": ["Sales", "Service", "Inquiries"],
         "values": [by_type.get("sales", 0), by_type.get("service", 0), by_type.get("inquiry", 0)],
@@ -5070,9 +5080,14 @@ def analytics_service(request: HttpRequest):
     prev_end = start_date - timezone.timedelta(days=1)
     prev_start = prev_end - timezone.timedelta(days=trend_days - 1)
     prev_qs = scope_queryset(Order.objects.filter(created_at__date__gte=prev_start, created_at__date__lte=prev_end), request.user, request)
+    prev_by_type_raw = {r["type"] or "": r["c"] for r in prev_qs.values("type").annotate(c=Count("id"))}
+    prev_by_type = {"sales": 0, "service": 0, "inquiry": 0}
+    for t, c in prev_by_type_raw.items():
+        prev_by_type[norm_type(t)] = prev_by_type.get(norm_type(t), 0) + int(c or 0)
+
     def pct_change(curr, prev):
         return round(((curr - prev) * 100.0) / (prev if prev else 1), 1)
-    prev_by_type = {r["type"] or "": r["c"] for r in prev_qs.values("type").annotate(c=Count("id"))}
+
     kpis = {
         "total_orders": total_orders,
         "total_tire_sales": total_sales,


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses critical issues with the analytics dashboard:
- Corrects total order count discrepancies between dashboard and analytics views
- Implements proper time-based filtering for KPI calculations and data export
- Ensures KPI values refresh correctly when time filters are applied

## Code Changes

### Template Updates (`analytics_service.html`)
- **KPI Data Source**: Replaced hardcoded static values with dynamic `kpis` object for all metrics
- **Dynamic Indicators**: Added conditional logic for percentage change indicators (green/red arrows based on positive/negative trends)
- **Consistent Formatting**: Applied uniform styling and data binding across Total Orders, Tire Sales, Car Service, and Inquiries KPIs

### Backend Logic (`views.py`)
- **Type Normalization**: Added `norm_type()` function to standardize order type categorization (handles legacy "consultation" → "inquiry" mapping)
- **Dual KPI Calculation**: 
  - Time-filtered KPIs for period-specific analytics
  - All-time KPIs to match dashboard totals
- **Improved Data Aggregation**: Enhanced type-based counting with proper normalization across all chart data
- **Period Comparison**: Added percentage change calculations comparing current period to previous period of same duration

### Key Fixes
- Total orders now correctly aggregate across normalized types
- KPI values properly respond to date range filters
- Inquiry data includes legacy consultation records
- Consistent data presentation between dashboard and analytics viewsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/153fe455da8744c4acc1b28d1a8dbc56/swoosh-realm)

👀 [Preview Link](https://153fe455da8744c4acc1b28d1a8dbc56-swoosh-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>153fe455da8744c4acc1b28d1a8dbc56</projectId>-->
<!--<branchName>swoosh-realm</branchName>-->